### PR TITLE
Wrong index offset when appending > 128 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file. This change
 - Timestamps for historical versions
 - Optimize (speed+size of) low level index format
 
+## [0.9.0-beta8] - 2023-10-04
+
+### Fixed
+
+- Indexing didn't work when appending more than [batch size] documents
+
+NB: [batch size] is currently set to 128.
+
 ## [0.9.0-beta6+7] - 2023-10-03
 
 - Append documents to existing nd-db files (previously v1.0.0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # nd-db
 
 ```clojure
-[com.luposlip/nd-db "0.9.0-beta7"]
+[com.luposlip/nd-db "0.9.0-beta8"]
 ```
 
 _Newline Delimited (read-only) Databases!_

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.luposlip/nd-db "0.9.0-beta7"
+(defproject com.luposlip/nd-db "0.9.0-beta8"
   :description "Clojure library to use newline delimited files as fast read-only databases."
   :url "https://github.com/luposlip/nd-db"
   :license {:name "Apache License, Version 2.0"

--- a/src/nd_db/core.clj
+++ b/src/nd_db/core.clj
@@ -178,15 +178,16 @@ meaning DON'T do parallel writes to database..!"
   (when (or (nil? doc-emitter)
             log-limit)
     (throw (ex-info "Can't write to historical database (when log-limit is set)!" {:log-limit log-limit})))
-  (let [docs (if (map? doc-or-docs)
-               [doc-or-docs]
-               doc-or-docs)]
-    (loop [all-docs-part (partition-all 128 docs)
+  (let [all-docs (if (map? doc-or-docs)
+                   [doc-or-docs]
+                   doc-or-docs)]
+    (loop [docs-parts (partition-all 128 all-docs)
            aggr-db db]
-      (if (empty? all-docs-part)
+      (if (empty? docs-parts)
         aggr-db
-        (let [docs-part-stringed (map doc-emitter (first all-docs-part))]
-          (recur (rest all-docs-part)
+        (let [docs-part (first docs-parts)
+              docs-part-stringed (map doc-emitter docs-part)]
+          (recur (rest docs-parts)
                  (-> aggr-db
                      (emit-docs (->> docs-part-stringed (str/join "\n")))
-                     (ndix/append docs docs-part-stringed))))))))
+                     (ndix/append docs-part docs-part-stringed))))))))

--- a/test/nd_db/core_test.clj
+++ b/test/nd_db/core_test.clj
@@ -288,6 +288,10 @@
         "New index line count is old line count plus docs appended")
     (is (not= (first docs) (nddb/q db 1)) "Old db returns old doc")
     (is (= (first docs) (nddb/q new-db 1)) "New db returns new version")
+
+    (let [fresh-db (nddb/db :filename tmp-filename :id-path :id)]
+      (-> fresh-db :index deref)
+      (is (= (peek docs) (-> fresh-db (nddb/q 222))) "Re-read updated index & q"))
     (delete-meta db)
     (io/delete-file tmp-filename)))
 


### PR DESCRIPTION
The first offset is set incorrectly, when adding more than 128 docs to a large database.

- [ ] Does it work when appending less than 128 docs?
- [ ] Does it work when appending > 128 docs to large database?